### PR TITLE
fix: Grant write permissions to frontend deployment workflow

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This commit fixes the GitHub Pages deployment workflow by adding the `permissions: contents: write` block.

The previous version of the workflow was failing with a permission denied error (403) because the default `GITHUB_TOKEN` did not have sufficient permissions to push the built static site to the `gh-pages` branch.

This change explicitly grants the necessary write permissions to the workflow, which will allow it to successfully deploy the frontend to GitHub Pages.